### PR TITLE
Added a y-axis attribute to set the y axis at something other than the minimum if desired

### DIFF
--- a/lib/SVG/Plot.pm
+++ b/lib/SVG/Plot.pm
@@ -692,6 +692,8 @@ distance of labels and I<y> ticks.
 
 By default the C<y> axis is scaled between the minimum and maximum y values.
 Set this if you want the C<y> axis to scale off of a different lower bound.
+Only has an effect if the C<$.min-y-axis> value is less then the minimum C<y>
+value.
 
 =head1 LICENSE AND COPYRIGHT
 


### PR DESCRIPTION
Defaults to 0. Set to +Inf (or some other suitably large value) to get previous behaviour. For a use case see: http://rosettacode.org/wiki/Plot_coordinate_pairs#Perl_6 
May or may not be something you want, but I find it useful.
Cheers.
