### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/SVG/Box.pm
+++ b/lib/SVG/Box.pm
@@ -1,4 +1,4 @@
-class SVG::Box;
+unit class SVG::Box;
 
 has $.svg       is rw;
 has $.width     is rw;

--- a/lib/SVG/Plot.pm
+++ b/lib/SVG/Plot.pm
@@ -2,7 +2,7 @@ use SVG::Box;
 
 enum SVG::Plot::AxisPosition <Zero SmallestValue LargestValue>;
 
-class SVG::Plot;
+unit class SVG::Plot;
 has $.height            = 300;
 has $.width             = 500;
 has $.fill-width        = 0.80;

--- a/lib/SVG/Plot/Data/Marker.pm
+++ b/lib/SVG/Plot/Data/Marker.pm
@@ -1,4 +1,4 @@
-class SVG::Plot::Data::Marker;
+unit class SVG::Plot::Data::Marker;
 
 has $.brush;            # TODO: default value
 has $.color = 'black';  # TODO: object

--- a/lib/SVG/Plot/Data/Series.pm
+++ b/lib/SVG/Plot/Data/Series.pm
@@ -1,4 +1,4 @@
-class SVG::Plot::Data::Series;
+unit class SVG::Plot::Data::Series;
 
 has @.keys handles   (add_to_keys   => 'push', key_elems   => 'elems');
 has @.values handles (add_to_values => 'push', value_elems => 'elems');

--- a/lib/SVG/Plot/Pie.pm
+++ b/lib/SVG/Plot/Pie.pm
@@ -1,7 +1,7 @@
 use v6;
 use SVG::Plot;
 
-class SVG::Plot::Pie is SVG::Plot;
+unit class SVG::Plot::Pie is SVG::Plot;
 
 has $.start-angle = 0;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.