### PR TITLE
Add Travis config file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: perl6
+
+perl6:
+    - latest
+    - 2016.01
+
+install:
+    - rakudobrew build-zef
+    - zef update && zef install SVG
+script:
+    - PERL6LIB=lib prove -v -r --exec=perl6 t/


### PR DESCRIPTION
It won't actually do anything until you go to https://travis-ci.org/auth and activate it.

There's no status badge in the README, because it's a plain-text readme instead of markdown.